### PR TITLE
Fix build error caused by SCSS import

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,7 +1,7 @@
 ---
 ---
 
-@import "jekyll-theme-minimal";
+//@import "minimal-mistakes";
 
 
 /* 1) Optionally import Google Fonts directly in SCSS */


### PR DESCRIPTION
## Summary
- comment out unused jekyll-theme import in `style.scss`

## Testing
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_685227eaf08c83259ebbd2af3b043a76